### PR TITLE
Upload documents table implemented with download and delete options

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.13",
     "memoize-one": "4.0.0",
     "mkdirp": "0.5.1",
-    "moment": "2.18.1",
+    "moment": "^2.24.0",
     "moxios": "^0.4.0",
     "node-sass": "^4.12.0",
     "node-sass-chokidar": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "d3-array": "^1.2.1",
     "d3-scale": "^2.1.0",
     "d3-time": "^1.0.8",
+    "downloadjs": "^1.4.7",
     "enzyme": "3.0.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-redux": "^0.2.1",

--- a/src/actions/healthRecords.js
+++ b/src/actions/healthRecords.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import download from 'downloadjs';
 import * as types from './types';
 
 // ------------------------- LOAD HEALTH RECORD ---------------------------- //
@@ -114,8 +115,7 @@ export function uploadDocument(documentFile) {
 
     return sendUploadDocumentRequest(accessToken, activeProfileId, documentFile)
       .then(data => dispatch(uploadDocumentSuccess(data)))
-      .catch(error => dispatch(uploadDocumentFailure(error)))
-      .then(() => dispatch(loadDocuments()));
+      .catch(error => dispatch(uploadDocumentFailure(error)));
   };
 }
 
@@ -169,5 +169,35 @@ export function loadDocuments() {
     return sendLoadDocumentsRequest(accessToken, activeProfileId)
       .then(data => dispatch(loadDocumentsSuccess(data)))
       .catch(error => dispatch(loadDocumentsFailure(error)));
+  };
+}
+
+export function downloadDocument(documentId, filename) {
+  return async (dispatch, getState) => {
+    const { auth: { accessToken } } = getState();
+
+    const { data, headers } = await axios.get(`/api/pilot/uploaded_documents/${documentId}/download`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      },
+      responseType: 'blob'
+    });
+    const contentType = headers['content-type'];
+
+    download(data, filename, contentType);
+  };
+}
+
+export function deleteDocument(documentId) {
+  return async (dispatch, getState) => {
+    const { auth: { accessToken } } = getState();
+
+    await axios.delete(`/api/pilot/uploaded_documents/${documentId}`, {
+      headers: {
+        'X-Key-Inflection': 'camel',
+        'Accept': 'application/json',
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
   };
 }

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -30,8 +30,6 @@ const THEME = createMuiTheme({
   },
   palette: {
     primary: { light: '#d4e4f6', main: '#6b8eb6', dark: '#5c7ca1', contrastText: '#fff' },
-    secondary: { light: '#96A5B7', main: '#7E90A3', dark: '#6C7988', contrastText: '#fff' },
-    error: { light: '#d08c9f', main: '#b66b80', dark: '#a44d65', contrastText: '#fff' },
     action: { selected: '#d4e4f6' }
   },
   shape: {}

--- a/src/containers/dashboard/UploadRecords.js
+++ b/src/containers/dashboard/UploadRecords.js
@@ -5,13 +5,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useDropzone } from 'react-dropzone';
 import Button from '@material-ui/core/Button';
 
-import { uploadDocument, loadDocuments } from '../../actions/healthRecords';
+import { uploadDocument, loadDocuments, downloadDocument, deleteDocument } from '../../actions/healthRecords';
 
 import renderDate from '../../utils/dates';
 
 import Banner from '../../components/elements/Banner';
 
 export const UploadRecords = ({
+  deleteDocument,
+  downloadDocument,
   isUploadingDocument,
   loadDocuments,
   uploadDocument,
@@ -32,7 +34,7 @@ export const UploadRecords = ({
     }
 
     setShowUploadErrorBanner(false);
-    uploadDocument(file);
+    await uploadDocument(file);
     loadDocuments();
   }, []);
 
@@ -77,13 +79,28 @@ export const UploadRecords = ({
               </tr>
             </thead>
             <tbody>
-              {uploadedDocuments.map(document => (
-                <tr key={document.id}>
-                  <td className="uploaded-records__tablecell-wide">{document.filename}</td>
-                  <td className="uploaded-records__tablecell-short">{renderDate(document.updated_at)}</td>
+              {uploadedDocuments.map(doc => (
+                <tr key={doc.id}>
+                  <td className="uploaded-records__tablecell-wide">{doc.filename}</td>
+                  <td className="uploaded-records__tablecell-short">{renderDate(doc.updated_at)}</td>
                   <td className="uploaded-records__tablecell-button">
-                    <Button mini={true} color="primary" onClick={() => {}}>View</Button>
-                    <Button mini={true} color="secondary" onClick={() => {}}>Delete</Button>
+                    <Button
+                      color="primary"
+                      onClick={() => downloadDocument(doc.id, doc.filename)}
+                      mini
+                    >
+                      Download
+                    </Button>
+                    <Button
+                      color="secondary"
+                      onClick={async () => {
+                        await deleteDocument(doc.id);
+                        loadDocuments();
+                      }}
+                      mini
+                    >
+                      Delete
+                    </Button>
                   </td>
                 </tr>
               ))}
@@ -100,7 +117,9 @@ UploadRecords.propTypes = {
   isUploadingDocument: PropTypes.bool.isRequired,
   uploadDocumentStatus: PropTypes.string,
   loadDocuments: PropTypes.func.isRequired,
-  uploadDocument: PropTypes.func.isRequired
+  uploadDocument: PropTypes.func.isRequired,
+  downloadDocument: PropTypes.func.isRequired,
+  deleteDocument: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
@@ -111,4 +130,7 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, { uploadDocument, loadDocuments })(UploadRecords);
+export default connect(
+  mapStateToProps,
+  { uploadDocument, loadDocuments, downloadDocument, deleteDocument }
+)(UploadRecords);

--- a/src/containers/dashboard/UploadRecords.js
+++ b/src/containers/dashboard/UploadRecords.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useDropzone } from 'react-dropzone';
+import Button from '@material-ui/core/Button';
 
 import { uploadDocument, loadDocuments } from '../../actions/healthRecords';
+
+import renderDate from '../../utils/dates';
 
 import Banner from '../../components/elements/Banner';
 
@@ -65,18 +68,23 @@ export const UploadRecords = ({
         </div>
 
         <div className="uploaded-records">
-          <table>
+          <table className="uploaded-records__table">
             <thead>
               <tr>
                 <th>File Name</th>
                 <th>Uploaded</th>
+                <th aria-label="buttons"></th>
               </tr>
             </thead>
             <tbody>
               {uploadedDocuments.map(document => (
                 <tr key={document.id}>
-                  <td>{document.filename}</td>
-                  <td>{document.updated_at}</td>
+                  <td className="uploaded-records__tablecell-wide">{document.filename}</td>
+                  <td className="uploaded-records__tablecell-short">{renderDate(document.updated_at)}</td>
+                  <td className="uploaded-records__tablecell-button">
+                    <Button mini={true} color="primary" onClick={() => {}}>View</Button>
+                    <Button mini={true} color="secondary" onClick={() => {}}>Delete</Button>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -7,6 +7,7 @@
 
 /* ------------------------- IMPORT CUSTOM SCSS ---------------------------- */
 // site-wide elements
+@import 'elements/mixins'; // keep first in list
 @import 'elements/badges';
 @import 'elements/banners';
 @import 'elements/base';

--- a/src/styles/containers/_upload-records.scss
+++ b/src/styles/containers/_upload-records.scss
@@ -1,4 +1,45 @@
 .upload-records {
   margin: 40px 0;
   padding: $global-padding;
+  font-size: 1.1em;
+
+  .uploaded-records {
+    margin-top: 40px;
+
+    &__table {
+      @include responsive-table;
+
+      width: 100%;
+
+      tbody tr {
+        &:hover {
+          background-color: lighten($color-blue-gray-light, 15%);
+        }
+      }
+
+      th, td {
+        padding: 0.1em 1em;
+      }
+
+      td:last-of-type {
+        text-align: right;
+      }
+    }
+
+    &__tablecell-wide {
+      width: 15em;
+    }
+
+    &__tablecell-short {
+      width: 11em;
+    }
+
+    &__tablecell-button {
+      white-space: nowrap;
+
+      button {
+        margin-left: 10px;
+      }
+    }
+  }
 }

--- a/src/styles/elements/_mixins.scss
+++ b/src/styles/elements/_mixins.scss
@@ -1,0 +1,61 @@
+@mixin button(
+  $color-text: $default-button-text-color,
+  $color-background: $default-button-bg-color,
+  $color-border: $default-button-border-color,
+  $color-border-hover: $default-button-border-hover-color,
+  $box-shadow: $box-shadow) {
+  background-color: $color-background;
+  color: $color-text;
+  border: $border-width solid $color-border;
+  box-shadow: $box-shadow;
+  transition: 0.2s ease-in-out;
+  text-transform: uppercase;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: $color-text;
+    color: $color-background;
+    border-color: $color-border-hover;
+    box-shadow: $box-shadow;
+  }
+
+  &:active {
+    box-shadow: none;
+  }
+}
+
+// make a table collapse to a list below a specified width
+// assumes cells have a data-th attribute present.
+@mixin responsive-table($breakpoint: 480px) {
+  thead {
+    @media (max-width: $breakpoint) {
+      display: none;
+    }
+  }
+
+  th,
+  td {
+    @media (max-width: $breakpoint) {
+      display: block;
+      padding: 0.25em 0.5em;
+      border-bottom: 0;
+    }
+
+    &::before {
+      @media (max-width: $breakpoint) {
+        content: attr(data-th);
+        display: block;
+        font-weight: $font-weight-bold;
+        text-transform: uppercase;
+        font-size: 0.9em;
+      }
+    }
+
+    &:last-child {
+      @media (max-width: $breakpoint) {
+        margin-bottom: 2em;
+      }
+    }
+  }
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,0 +1,7 @@
+import moment from 'moment';
+
+export default function renderDate(datetime) {
+  let formattedDate = '';
+  if (datetime) { formattedDate = moment(datetime).fromNow(); }
+  return formattedDate;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6762,13 +6762,14 @@ moment-duration-format@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-1.3.0.tgz#541771b5f87a049cc65540475d3ad966737d6908"
 
-moment@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-
 moment@2.x, moment@^2.10.3, moment@^2.14.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 moxios@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,6 +3245,11 @@ dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+  integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
This PR implements the download and delete document buttons as well as styles the table for uploaded documents.

Out of scope for this task but possible improvements in the future can include viewing the document in the browser and adding a confirmation modal when deleting a document.

<img width="1110" alt="Screen Shot 2020-01-30 at 10 34 19 AM" src="https://user-images.githubusercontent.com/5418735/73464061-4dcbd180-434c-11ea-82db-4dfd04119f4c.png">
